### PR TITLE
Fix: Avoid non-native interactive elements.

### DIFF
--- a/templates/school/admin_dashboard.html
+++ b/templates/school/admin_dashboard.html
@@ -48,7 +48,7 @@
 </div><br>
 {%for n in notice%}
 <div class="alert">
-  <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
+  <span class="closebtn" onclick="this.parentElement.style.display='none' role="button";">&times;</span>
   <strong>{{n.date}} ||By :{{n.by}} </strong><br> {{n.message}}
 </div>
 {%endfor%}


### PR DESCRIPTION
(If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element.)